### PR TITLE
Rename is_struct into is_struct_module to not conflict with the Kernel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # The directory Mix will write compiled artifacts to.
 /_build/
+.elixir_ls/
 
 # If you run "mix test --cover", coverage assets end up here.
 /cover/

--- a/lib/brex/rule/struct.ex
+++ b/lib/brex/rule/struct.ex
@@ -29,7 +29,7 @@ defmodule Brex.Rule.Struct do
   end
 
   def __after_compile__(%{module: module} = env, _bytecode) do
-    is_struct(module) ||
+    is_struct_module(module) ||
       raise CompileError,
         file: env.file,
         line: env.line,
@@ -44,7 +44,7 @@ defmodule Brex.Rule.Struct do
           "cannot use #{inspect(__MODULE__)} on module #{inspect(module)} without defining evaluate/2"
   end
 
-  defp is_struct(module) do
+  defp is_struct_module(module) do
     function_exported?(module, :__struct__, 0) and function_exported?(module, :__struct__, 1)
   end
 


### PR DESCRIPTION
By renaming `is_struct` into ìs_struct_module` we can avoid conflicts with newer versions of Elixir :) 