### PR TITLE
Load using-module bytecode before @after_compile checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
     with:
       matrix: |
         [
+          {"elixir": "1.19", "otp": "28.0", "alpine": "3.21"},
           {"elixir": "1.18", "otp": "27.0", "alpine": "3.20"},
           {"elixir": "1.17", "otp": "27.0", "alpine": "3.20"},
           {"elixir": "1.16", "otp": "26.2", "alpine": "3.20"}

--- a/lib/brex/rule/struct.ex
+++ b/lib/brex/rule/struct.ex
@@ -28,7 +28,9 @@ defmodule Brex.Rule.Struct do
     end
   end
 
-  def __after_compile__(%{module: module} = env, _bytecode) do
+  def __after_compile__(%{module: module} = env, bytecode) do
+    ensure_loaded!(module, bytecode)
+
     is_struct_module(module) ||
       raise CompileError,
         file: env.file,
@@ -42,6 +44,17 @@ defmodule Brex.Rule.Struct do
         line: env.line,
         description:
           "cannot use #{inspect(__MODULE__)} on module #{inspect(module)} without defining evaluate/2"
+  end
+
+  defp ensure_loaded!(module, bytecode) do
+    case Code.ensure_loaded(module) do
+      {:module, ^module} ->
+        :ok
+
+      {:error, _} ->
+        {:module, ^module} = :code.load_binary(module, ~c"nofile", bytecode)
+        :ok
+    end
   end
 
   defp is_struct_module(module) do


### PR DESCRIPTION
Elixir 1.19's compiler no longer auto-loads the using module before @after_compile fires, so function_exported?/2 reports false for the freshly compiled struct and Brex.Operator (and any user struct rule) fails to compile with "is not a struct".

Force-load the bytecode passed to the callback before running the struct + evaluate/2 checks, and add Elixir 1.19 / OTP 28 to the CI matrix so the regression is caught upstream.